### PR TITLE
Bug fix and change interface of `TwoDimensionalNonlinearOscillator`

### DIFF
--- a/src/environments/basics/TwoDimensionalNonlinearOscillator.jl
+++ b/src/environments/basics/TwoDimensionalNonlinearOscillator.jl
@@ -50,6 +50,6 @@ end
 function OptimalControl(env::TwoDimensionalNonlinearOscillator)
     return function (x)
         @unpack x1, x2 = x
-        u_star = -3*x2
+        u_star = [-3*x2]  # make it vector
     end
 end


### PR DESCRIPTION
input `u` is now an `Array`, e.g., `[1.0]`, not a `Number`.